### PR TITLE
Display suggestions in jinja

### DIFF
--- a/week2/templates/did_you_mean.jinja2
+++ b/week2/templates/did_you_mean.jinja2
@@ -1,12 +1,16 @@
 {% if search_response.suggest is defined %}
   <div>
-    {% if (search_response.suggest.phrase_suggest is defined or search_response.suggest.term_suggest is defined) and (search_response.suggest.phrase_suggest|length > 0 or search_response.suggest.term_suggest|length > 0) and (search_response.suggest.phrase_suggest[0].options|length  > 0 or search_response.suggest.term_suggest[0].options|length  > 0 ) %}
+    {% if (search_response.suggest.phrase_suggest is defined or search_response.suggest.term_suggest is defined) 
+      and (search_response.suggest.phrase_suggest|length > 0 or search_response.suggest.term_suggest|length > 0) 
+      and (search_response.suggest.phrase_suggest[0].options|length  > 0 or (
+        search_response.suggest.term_suggest.options is defined and
+        search_response.suggest.term_suggest[0].options|length  > 0)) %}
       Did you mean?
     {% endif %}
-    {% if search_response.suggest.phrase_suggest is defined and search_response.suggest.phrase_suggest|length > 0 and search_response.suggest.phrase_suggest[0].options|length  > 0 %}
+    {% if search_response.suggest.phrase_suggest is defined and search_response.suggest.phrase_suggest|length > 0 and search_response.suggest.phrase_suggest[0].options|length > 0 %}
       <label>Phrase suggestions</label>: {{ search_response.suggest.phrase_suggest[0].options[0].highlighted }}
     {% endif %}
-    {% if search_response.suggest.term_suggest is defined and search_response.suggest.term_suggest|length > 0 and search_response.suggest.term_suggest[0].options|length  > 0 %}
+    {% if search_response.suggest.term_suggest is defined and search_response.suggest.term_suggest|length > 0 and search_response.suggest.term_suggest[0].options|length > 0 %}
       <label>Term suggestions</label>: {{ search_response.suggest.term_suggest[0].options[0].text }}
     {% endif %}
   </div>

--- a/week2/templates/did_you_mean.jinja2
+++ b/week2/templates/did_you_mean.jinja2
@@ -1,13 +1,11 @@
 {% if search_response.suggest is defined %}
   <div>
-    hola
     {% if (search_response.suggest.phrase_suggest is defined or search_response.suggest.term_suggest is defined) and (search_response.suggest.phrase_suggest|length > 0 or search_response.suggest.term_suggest|length > 0) and (search_response.suggest.phrase_suggest[0].options|length  > 0 or search_response.suggest.term_suggest[0].options|length  > 0 ) %}
-    hi
-      Did you mean?{% endif %}
+      Did you mean?
+    {% endif %}
     {% if search_response.suggest.phrase_suggest is defined and search_response.suggest.phrase_suggest|length > 0 and search_response.suggest.phrase_suggest[0].options|length  > 0 %}
       <label>Phrase suggestions</label>: {{ search_response.suggest.phrase_suggest[0].options[0].highlighted }}
     {% endif %}
-    hello
     {% if search_response.suggest.term_suggest is defined and search_response.suggest.term_suggest|length > 0 and search_response.suggest.term_suggest[0].options|length  > 0 %}
       <label>Term suggestions</label>: {{ search_response.suggest.term_suggest[0].options[0].text }}
     {% endif %}

--- a/week2/templates/did_you_mean.jinja2
+++ b/week2/templates/did_you_mean.jinja2
@@ -1,10 +1,13 @@
-{% if suggest in search_response %}
+{% if search_response.suggest is defined %}
   <div>
+    hola
     {% if (search_response.suggest.phrase_suggest is defined or search_response.suggest.term_suggest is defined) and (search_response.suggest.phrase_suggest|length > 0 or search_response.suggest.term_suggest|length > 0) and (search_response.suggest.phrase_suggest[0].options|length  > 0 or search_response.suggest.term_suggest[0].options|length  > 0 ) %}
+    hi
       Did you mean?{% endif %}
     {% if search_response.suggest.phrase_suggest is defined and search_response.suggest.phrase_suggest|length > 0 and search_response.suggest.phrase_suggest[0].options|length  > 0 %}
       <label>Phrase suggestions</label>: {{ search_response.suggest.phrase_suggest[0].options[0].highlighted }}
     {% endif %}
+    hello
     {% if search_response.suggest.term_suggest is defined and search_response.suggest.term_suggest|length > 0 and search_response.suggest.term_suggest[0].options|length  > 0 %}
       <label>Term suggestions</label>: {{ search_response.suggest.term_suggest[0].options[0].text }}
     {% endif %}


### PR DESCRIPTION
* Fix did-you-mean suggestions not showing up in UI
* Added check for whether `options` exist in `response['suggest']['term_suggest']`. On my initial load, response['suggest']['term_suggest']` returned empty `{}`, and raised Undefined Error when template tried to access options


ex. `response['suggest']['term_suggest']`:

<img width="703" alt="Screen Shot 2022-06-11 at 6 43 41 PM" src="https://user-images.githubusercontent.com/1931494/173182671-74b5b782-c752-4696-a2b3-818e90d962b1.png">
